### PR TITLE
[2022.11.26] feat: 인접 선분 병합 및 정렬 알고리즘 추가, 선분 인식기능 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layout-generator-client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "dependencies": {
     "@techstark/opencv-js": "^4.6.0-release.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layout-generator-client",
-  "version": "0.1.5",
+  "version": "0.1.4",
   "private": true,
   "dependencies": {
     "@techstark/opencv-js": "^4.6.0-release.1",

--- a/src/components/Canvas/Canvas.js
+++ b/src/components/Canvas/Canvas.js
@@ -1,119 +1,111 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState, useRecoilState } from "recoil";
 import cv from "@techstark/opencv-js";
 
 import {
   imageURLState,
-  imageSizeState,
   detectedLinesState,
+  imageSizeState,
 } from "../../recoil/store";
 import fitToMaxCanvasSize from "../../utils/fitToMaxCanvasSize";
+import sortAndMergeLines from "../../utils/sortAndMergeLines";
 
-export default function Canvas({ weight, initialState = true }) {
+export default function Canvas({ weight }) {
   const imageURL = useRecoilValue(imageURLState);
-  const setImageSize = useSetRecoilState(imageSizeState);
+  const [imageSize, setImageSize] = useRecoilState(imageSizeState);
   const setDetectedLines = useSetRecoilState(detectedLinesState);
 
-  const [isInitialLoad, setIsInitialLoad] = useState(initialState);
+  const [canvasSize, setCanvasSize] = useState({});
   const [preProcessedData, setPreProcessedData] = useState(null);
 
   const canvasRef = useRef();
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    const image = new Image();
-    image.src = imageURL;
 
-    image.onload = () => {
-      const input = cv.imread(image);
-      const rowLines = [];
-      const columnLines = [];
-      const { width, height } = fitToMaxCanvasSize(image.width, image.height);
+    if (!preProcessedData) {
+      const image = new Image();
 
-      setImageSize({ width: image.width, height: image.height });
+      image.src = imageURL;
+      image.onload = () => {
+        const input = cv.imread(image);
+        const { cols, rows } = input;
+        const { width, height } = fitToMaxCanvasSize(cols, rows);
 
-      const preProcessingImage = () => {
         cv.cvtColor(input, input, cv.COLOR_RGB2GRAY, 0);
         cv.Canny(input, input, 25, 75, 3, false);
+        // cv.imshow(cannyCanvas, input);
 
         setPreProcessedData(input);
-        setIsInitialLoad(false);
+        setCanvasSize({ width, height });
+        setImageSize({ width: cols, height: rows });
       };
+    } else {
+      const detectedLines = new cv.Mat();
+      const output = new cv.Mat();
+      const linedOutput = cv.Mat.zeros(
+        preProcessedData.rows,
+        preProcessedData.cols,
+        cv.CV_8UC3
+      );
+      const lineColor = new cv.Scalar(255, 247, 53);
+      const fittedSize = new cv.Size(canvasSize.width, canvasSize.height);
+      const minimumLineLength = Math.floor(
+        preProcessedData.cols * (weight / 100)
+      );
 
-      const detectLines = () => {
-        const lines = new cv.Mat();
-        const minimumLineLength = Math.floor(input.cols * (weight / 100));
+      const rowPoints = [];
+      const columnPoints = [];
 
-        cv.HoughLinesP(
-          preProcessedData,
-          lines,
-          1,
-          Math.PI / 180,
-          2,
-          minimumLineLength,
-          20
-        );
+      cv.HoughLinesP(
+        preProcessedData,
+        detectedLines,
+        1,
+        Math.PI / 180,
+        2,
+        minimumLineLength,
+        60
+      );
 
-        for (let i = 0; i < lines.rows; i++) {
-          const line = {
-            startX: lines.data32S[i * 4],
-            startY: lines.data32S[i * 4 + 1],
-            endX: lines.data32S[i * 4 + 2],
-            endY: lines.data32S[i * 4 + 3],
-          };
+      for (let i = 0; i < detectedLines.rows; i++) {
+        const line = {
+          startX: detectedLines.data32S[i * 4],
+          startY: detectedLines.data32S[i * 4 + 1],
+          endX: detectedLines.data32S[i * 4 + 2],
+          endY: detectedLines.data32S[i * 4 + 3],
+        };
 
-          if (line.startY === line.endY) {
-            rowLines.push(line);
-          } else {
-            columnLines.push(line);
-          }
+        if (line.startY === line.endY) {
+          rowPoints.push(line);
+        } else {
+          columnPoints.push(line);
         }
-
-        rowLines.sort((a, b) => a.startY - b.startY);
-        columnLines.sort((a, b) => a.startX - b.startX);
-
-        setDetectedLines({ rowLines, columnLines });
-
-        lines.delete();
-      };
-
-      const drawLines = (lines) => {
-        const linedOutput = cv.Mat.zeros(
-          preProcessedData.rows,
-          preProcessedData.cols,
-          cv.CV_8UC3
-        );
-        const output = new cv.Mat();
-        const color = new cv.Scalar(255, 247, 53);
-
-        lines.forEach((line) => {
-          const { startX, startY, endX, endY } = line;
-          const startPoint = new cv.Point(startX, startY);
-          const endPoint = new cv.Point(endX, endY);
-
-          cv.line(linedOutput, startPoint, endPoint, color, 5);
-        });
-
-        const matSize = new cv.Size(width, height);
-        cv.resize(linedOutput, output, matSize, 0, 0, cv.INTER_AREA);
-        cv.imshow(canvas, output);
-
-        input.delete();
-        linedOutput.delete();
-        output.delete();
-      };
-
-      if (isInitialLoad) {
-        preProcessingImage();
-      } else {
-        detectLines();
-        drawLines([...rowLines, ...columnLines]);
       }
-    };
+
+      const rowLines = sortAndMergeLines(rowPoints, imageSize.height);
+      const columnLines = sortAndMergeLines(columnPoints, imageSize.width);
+
+      [...rowLines, ...columnLines].forEach((line) => {
+        const startPoint = new cv.Point(line.startX, line.startY);
+        const endPoint = new cv.Point(line.endX, line.endY);
+
+        cv.line(linedOutput, startPoint, endPoint, lineColor, 5);
+      });
+
+      cv.resize(linedOutput, output, fittedSize, 0, 0, cv.INTER_AREA);
+      cv.imshow(canvas, output);
+
+      setDetectedLines({ rowLines, columnLines });
+
+      detectedLines.delete();
+      linedOutput.delete();
+      output.delete();
+    }
   }, [
-    isInitialLoad,
-    preProcessedData,
     imageURL,
+    imageSize,
+    canvasSize,
+    preProcessedData,
     setImageSize,
     setDetectedLines,
     weight,

--- a/src/components/Canvas/Canvas.js
+++ b/src/components/Canvas/Canvas.js
@@ -12,8 +12,8 @@ import sortAndMergeLines from "../../utils/sortAndMergeLines";
 
 export default function Canvas({ weight }) {
   const imageURL = useRecoilValue(imageURLState);
-  const [imageSize, setImageSize] = useRecoilState(imageSizeState);
   const setDetectedLines = useSetRecoilState(detectedLinesState);
+  const [imageSize, setImageSize] = useRecoilState(imageSizeState);
 
   const [canvasSize, setCanvasSize] = useState({});
   const [preProcessedData, setPreProcessedData] = useState(null);
@@ -34,7 +34,6 @@ export default function Canvas({ weight }) {
 
         cv.cvtColor(input, input, cv.COLOR_RGB2GRAY, 0);
         cv.Canny(input, input, 25, 75, 3, false);
-        // cv.imshow(cannyCanvas, input);
 
         setPreProcessedData(input);
         setCanvasSize({ width, height });
@@ -49,7 +48,7 @@ export default function Canvas({ weight }) {
         cv.CV_8UC3
       );
       const lineColor = new cv.Scalar(255, 247, 53);
-      const fittedSize = new cv.Size(canvasSize.width, canvasSize.height);
+      const adjustedSize = new cv.Size(canvasSize.width, canvasSize.height);
       const minimumLineLength = Math.floor(
         preProcessedData.cols * (weight / 100)
       );
@@ -64,7 +63,7 @@ export default function Canvas({ weight }) {
         Math.PI / 180,
         2,
         minimumLineLength,
-        60
+        20
       );
 
       for (let i = 0; i < detectedLines.rows; i++) {
@@ -92,7 +91,7 @@ export default function Canvas({ weight }) {
         cv.line(linedOutput, startPoint, endPoint, lineColor, 5);
       });
 
-      cv.resize(linedOutput, output, fittedSize, 0, 0, cv.INTER_AREA);
+      cv.resize(linedOutput, output, adjustedSize, 0, 0, cv.INTER_AREA);
       cv.imshow(canvas, output);
 
       setDetectedLines({ rowLines, columnLines });

--- a/src/components/LayoutPreview/LayoutPreview.js
+++ b/src/components/LayoutPreview/LayoutPreview.js
@@ -18,8 +18,7 @@ export default function LayoutPreview() {
   const gridTemplateColumns = getFractionString(columnLines, imageWidth);
 
   const divisions = [];
-  const { full, partial } = DIVISION_TYPE;
-  let currentDivision = full;
+  let currentDivision = DIVISION_TYPE.full;
   let currentLineIndex = 0;
   let intersection = 0;
   let intersectionIndex = 0;
@@ -57,11 +56,11 @@ export default function LayoutPreview() {
       while (divisions.length < rowLines.length + columnLines.length + 1) {
         intersection = columnLines[0].endY;
 
-        if (currentDivision === full) {
-          divisions.push(full);
+        if (currentDivision === DIVISION_TYPE.full) {
+          divisions.push(DIVISION_TYPE.full);
 
-          if (isInRange(rowLines[currentLineIndex].startY, intersection, 10)) {
-            currentDivision = partial;
+          if (isInRange(rowLines[currentLineIndex].startY, intersection, 20)) {
+            currentDivision = DIVISION_TYPE.partial;
             intersectionIndex = currentLineIndex;
             currentLineIndex = 0;
           } else {
@@ -69,14 +68,14 @@ export default function LayoutPreview() {
           }
         }
 
-        if (currentDivision === partial) {
+        if (currentDivision === DIVISION_TYPE.partial) {
           if (columnLines.length - 1 === currentLineIndex) {
-            divisions.push(partial, partial);
+            divisions.push(DIVISION_TYPE.partial, DIVISION_TYPE.partial);
 
-            currentDivision = full;
+            currentDivision = DIVISION_TYPE.full;
             currentLineIndex = intersectionIndex + 1;
           } else {
-            divisions.push(partial);
+            divisions.push(DIVISION_TYPE.partial);
 
             currentLineIndex += 1;
           }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,8 +1,8 @@
 const ACCEPTED_FILE_TYPE = ".jpeg, .png, .tiff, .bmp";
 
-const FRAME_TYPE = {
-  width: "width",
-  height: "height",
+const LINE_TYPE = {
+  row: "row",
+  column: "column",
 };
 
 const DIVISION_TYPE = {
@@ -19,18 +19,21 @@ const LAYOUT_TYPE = {
 
 const DEFAULT_WEIGHT = 50;
 
-const MAX_SIZE_MARGIN = 50;
+const MAX_SIZE_MARGIN = 20;
+
+const LINE_MERGE_LIMIT = 50;
 
 const MAX_CANVAS_SIZE = {
-  width: 600,
-  height: 600,
+  width: 800,
+  height: 800,
 };
 
 export {
   ACCEPTED_FILE_TYPE,
-  FRAME_TYPE,
+  LINE_TYPE,
   DIVISION_TYPE,
   LAYOUT_TYPE,
+  LINE_MERGE_LIMIT,
   DEFAULT_WEIGHT,
   MAX_SIZE_MARGIN,
   MAX_CANVAS_SIZE,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -21,7 +21,7 @@ const DEFAULT_WEIGHT = 50;
 
 const MAX_SIZE_MARGIN = 20;
 
-const LINE_MERGE_LIMIT = 50;
+const LINE_MERGE_LIMIT = 60;
 
 const MAX_CANVAS_SIZE = {
   width: 800,

--- a/src/pages/MainPage/MainPage.js
+++ b/src/pages/MainPage/MainPage.js
@@ -27,6 +27,7 @@ export default function MainPage() {
     reader.readAsDataURL(file);
     reader.onload = () => {
       setImageURL(reader.result);
+
       navigate("/preview");
     };
   };

--- a/src/pages/PreviewPage/PreviewPage.js
+++ b/src/pages/PreviewPage/PreviewPage.js
@@ -15,7 +15,6 @@ import { DEFAULT_WEIGHT } from "../../constants";
 
 export default function PreviewPage() {
   const imageURL = useRecoilValue(imageURLState);
-
   const [weight, setWeight] = useState(DEFAULT_WEIGHT);
 
   const navigate = useNavigate();

--- a/src/pages/PreviewPage/PreviewPage.js
+++ b/src/pages/PreviewPage/PreviewPage.js
@@ -13,9 +13,10 @@ import { imageURLState } from "../../recoil/store";
 
 import { DEFAULT_WEIGHT } from "../../constants";
 
-export default function PreviewPage() {
+export default function PreviewPage({ initialState = DEFAULT_WEIGHT }) {
   const imageURL = useRecoilValue(imageURLState);
-  const [weight, setWeight] = useState(DEFAULT_WEIGHT);
+
+  const [weight, setWeight] = useState(initialState);
 
   const navigate = useNavigate();
 

--- a/src/recoil/store.js
+++ b/src/recoil/store.js
@@ -16,12 +16,12 @@ const imageSizeState = atom({
 });
 
 const detectedLinesState = atom({
-  key: "detectedLines",
+  key: "detectedLinesState",
   default: {},
 });
 
 const generatedCodeState = atom({
-  key: "generatedCode",
+  key: "generatedCodeState",
   default: "",
 });
 

--- a/src/utils/sortAndMergeLines.js
+++ b/src/utils/sortAndMergeLines.js
@@ -1,0 +1,58 @@
+import isInRange from "./isInRange";
+
+import { LINE_MERGE_LIMIT, LINE_TYPE, MAX_SIZE_MARGIN } from "../constants";
+
+const sortAndMergeLines = (lines, lineLength) => {
+  if (!lines.length) {
+    return lines;
+  }
+
+  const copiedLines = [...lines];
+  const lineType =
+    copiedLines[0]?.startY === copiedLines[0]?.endY
+      ? LINE_TYPE.row
+      : LINE_TYPE.column;
+
+  return copiedLines
+    .sort((a, b) => {
+      if (lineType === LINE_TYPE.row) {
+        return a.startY - b.startY;
+      }
+
+      return a.startX - b.startX;
+    })
+    .reduce((result, line, index, array) => {
+      const { startX, startY } = line;
+      const currentPoint = lineType === LINE_TYPE.row ? startY : startX;
+
+      if (
+        currentPoint < MAX_SIZE_MARGIN ||
+        currentPoint > lineLength - MAX_SIZE_MARGIN
+      ) {
+        return result;
+      }
+
+      if (index === 0) {
+        result.push(line);
+
+        return result;
+      }
+
+      const prevPoint =
+        lineType === LINE_TYPE.row
+          ? array[index - 1].startY
+          : array[index - 1].startX;
+
+      const isMergeable = isInRange(currentPoint, prevPoint, LINE_MERGE_LIMIT);
+
+      if (isMergeable) {
+        return result;
+      }
+
+      result.push(line);
+
+      return result;
+    }, []);
+};
+
+export default sortAndMergeLines;


### PR DESCRIPTION
## 작업 사항
- 이미지에서 선분 인식 시, 하나의 선분이 다수로 나뉘어져 인식되는 상황에 대처하기 위해, 일정 기준치 이내에 있는 선분은 하나의 선분으로 병합하도록 하는 로직 추가
- 기존에 이미지가 로드된 후 실행되는 콜백에서 모든 opencv기능을 실행하였는데, 이를 초기 이미지 로드시에 전처리까지 진행후 완료된 opencv mat를 상태로 관리하도록 하였음. 그리고 이후의 이미지 처리 로직(선분 인식, 병합, 선 그리기 등)들은 이미지데이터 자체가 아닌 해당 상태(mat)를 이용하여 실행되게 수정하였음. 결과적으로 원인미상의 에러도 없어졌고 반응속도도 훨씬 좋아짐.

## 그 밖의 변경 사항
- 레이아웃 인식 관련 일부 메소드 파라미터 값 조절
- 코드 스타일 수정

## Before PR
- [x] 최신 branch pull
- [x] base branch 이름 확인
- [ ] version 업데이트 (필요한 경우)

## 참고사항
- [Canvan 링크](https://www.notion.so/Refactor-cf88205a065a4886b2c9a9ae52e646c4)
